### PR TITLE
Changed the search string for palette replacement

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -14,7 +14,7 @@
 /**
  * Table tl_page
  */
-$GLOBALS['TL_DCA']['tl_page']['palettes']['root'] = str_replace('{global_legend:hide},dateFormat,timeFormat,datimFormat,adminEmail;', '{global_legend:hide},dateFormat,timeFormat,datimFormat,adminEmail;{rsm_google_recaptcha_legend:hide},rsm_public_key,rsm_private_key;', $GLOBALS['TL_DCA']['tl_page']['palettes']['root']);
+$GLOBALS['TL_DCA']['tl_page']['palettes']['root'] = str_replace(';{alias_legend', ';{rsm_google_recaptcha_legend:hide},rsm_public_key,rsm_private_key;{alias_legend', $GLOBALS['TL_DCA']['tl_page']['palettes']['root']);
 
 $GLOBALS['TL_DCA']['tl_page']['fields']['rsm_public_key'] = array(
     'label'         => &$GLOBALS['TL_LANG']['tl_page']['rsm_public_key'],


### PR DESCRIPTION
The search string for the palette manipulation has changed in the core, so it doesn't get found and in consequence the fields aren't visible. 

Changed it to a more open approach.